### PR TITLE
Enable bitcode for all versions of iphoneos SDK.

### DIFF
--- a/Configurations/ParseFacebookUtilsV4-iOS.xcconfig
+++ b/Configurations/ParseFacebookUtilsV4-iOS.xcconfig
@@ -22,4 +22,4 @@ FRAMEWORK_SEARCH_PATHS = $(inherited) $(SRCROOT)/Vendor
 LIBRARY_SEARCH_PATHS = $(inherited) $(BUILT_PRODUCTS_DIR)
 HEADER_SEARCH_PATHS = $(inherited) $(BUILT_PRODUCTS_DIR)
 
-OTHER_CFLAGS[sdk=iphoneos9.0] = $(inherited) -fembed-bitcode
+OTHER_CFLAGS[sdk=iphoneos9.*] = $(inherited) -fembed-bitcode


### PR DESCRIPTION
Use star instead of hardcoding to 9.0.
