### PR TITLE
Improve visibility of initialization order.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
     - master-v3
 language: objective-c
 os: osx
-osx_image: xcode7.2
+osx_image: xcode7.3
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
+    activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -41,12 +41,12 @@ GEM
     fuzzy_match (2.0.4)
     i18n (0.7.0)
     json (1.8.3)
-    minitest (5.8.3)
-    molinillo (0.4.0)
-    nap (1.0.0)
+    minitest (5.8.4)
+    molinillo (0.4.4)
+    nap (1.1.0)
     naturally (2.1.0)
     netrc (0.7.8)
-    rake (10.4.2)
+    rake (11.1.2)
     rouge (1.10.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -55,7 +55,7 @@ GEM
       activesupport (>= 3)
       claide (~> 0.9.1)
       colored (~> 1.2)
-    xcpretty (0.2.1)
+    xcpretty (0.2.2)
       rouge (~> 1.8)
 
 PLATFORMS
@@ -68,4 +68,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/ParseFacebookUtils.xcodeproj/project.pbxproj
+++ b/ParseFacebookUtils.xcodeproj/project.pbxproj
@@ -553,7 +553,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = PF;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = "Parse, LLC";
 				TargetAttributes = {
 					81CB98C51AB7905D00136FA5 = {

--- a/ParseFacebookUtils.xcodeproj/xcshareddata/xcschemes/ParseFacebookUtilsV4-iOS.xcscheme
+++ b/ParseFacebookUtils.xcodeproj/xcshareddata/xcschemes/ParseFacebookUtilsV4-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ParseFacebookUtils.xcodeproj/xcshareddata/xcschemes/ParseFacebookUtilsV4-tvOS.xcscheme
+++ b/ParseFacebookUtils.xcodeproj/xcshareddata/xcschemes/ParseFacebookUtilsV4-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.m
+++ b/ParseFacebookUtils/Internal/PFFacebookPrivateUtilities.m
@@ -84,7 +84,12 @@
 }
 
 - (instancetype)pffb_continueWithMainThreadBlock:(BFContinuationBlock)block {
-    return [self continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:block];
+    return [self continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:^id(BFTask *task) {
+        if (task.exception) {
+            @throw task.exception;
+        }
+        return block(task);
+    }];
 }
 
 @end

--- a/ParseFacebookUtils/PFFacebookUtils.m
+++ b/ParseFacebookUtils/PFFacebookUtils.m
@@ -10,8 +10,8 @@
 #import "PFFacebookUtils.h"
 
 #import <Bolts/BFExecutor.h>
-
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <Parse/Parse.h>
 
 #import "PFFacebookPrivateUtilities.h"
 
@@ -48,6 +48,10 @@ static PFFacebookAuthenticationProvider *authenticationProvider_;
 ///--------------------------------------
 
 + (void)initializeFacebookWithApplicationLaunchOptions:(NSDictionary *)launchOptions {
+    if (![Parse currentConfiguration]) {
+        // TODO: (nlutsenko) Remove this when Parse SDK throws on every access to Parse._currentManager
+        [NSException raise:NSInternalInconsistencyException format:@"PFFacebookUtils must be initialized after initializing Parse."];
+    }
     if (!authenticationProvider_) {
         Class providerClass = nil;
 #if TARGET_OS_IOS

--- a/Tests/Unit/FacebookUtilsTests.m
+++ b/Tests/Unit/FacebookUtilsTests.m
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-@import Parse.PFConstants;
+@import Parse;
 
 #import <OCMock/OCMock.h>
 
@@ -57,9 +57,14 @@
 
     XCTAssertThrows([PFFacebookUtils unlinkUserInBackground:userMock]);
 
-    [PFFacebookUtils initializeFacebookWithApplicationLaunchOptions:nil];
-    XCTAssertNotNil([PFFacebookUtils _authenticationProvider]);
+    XCTAssertThrows([PFFacebookUtils initializeFacebookWithApplicationLaunchOptions:nil]);
 
+    id parseMock = PFStrictClassMock([Parse class]);
+    id configurationMock = PFStrictClassMock([ParseClientConfiguration class]);
+    OCMStub(ClassMethod([parseMock currentConfiguration])).andReturn(configurationMock);
+
+    XCTAssertNoThrow([PFFacebookUtils initializeFacebookWithApplicationLaunchOptions:nil]);
+    XCTAssertNotNil([PFFacebookUtils _authenticationProvider]);
     XCTAssertNoThrow([PFFacebookUtils initializeFacebookWithApplicationLaunchOptions:nil]);
 
     OCMVerifyAll(userMock);

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  comment: off
+  ignore:
+    - Tests/*
+  status:
+    project:
+      default:
+        target: 75
+        only_pulls: yes
+          


### PR DESCRIPTION
This should improve the visilbility of our initialization order requirement.
Thanks @demosten for catching the fact that we don't rethrow exceptions in the blocks.
